### PR TITLE
Fix fisher installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [the full list](conf.d/kubectl-fish-abbr.fish).
 Install with [fisher](https://github.com/jorgebucaran/fisher).
 
 ```fish
-fisher add DrPhil/kubectl-fish-abbr
+fisher install DrPhil/kubectl-fish-abbr
 ```
 
 ### Syntax explanation


### PR DESCRIPTION
fisher changed its install command from `add` to `install` with [v4.0.0](https://github.com/jorgebucaran/fisher/releases/tag/4.0.0)